### PR TITLE
Add untracked git state as brblack

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -36,8 +36,10 @@ function __mean_git_color
     echo 'brred'
   else if [ -n "$ahead" -a "$ahead" != '0' ]
     echo 'cyan'
-  else
+  else if [ "$remote" ]
     echo 'white'
+  else
+    echo 'brblack'
   end
 end
 

--- a/test/fish_prompt_test.fish
+++ b/test/fish_prompt_test.fish
@@ -23,14 +23,14 @@ cd $path
 
 assert 'base path' \
   '/p/t/fish-theme-mean-test ' \
-  '' 'white'
+  '' 'brblack'
 
 mkdir $path/repo
 cd $path/repo
 
 assert 'into inner folder' \
   '/p/t/f/repo ' \
-  '' 'white'
+  '' 'brblack'
 
 git_ init
 
@@ -49,13 +49,13 @@ git_ -c user.name=mariza -c user.email=mariza commit -m 'first commit'
 
 assert 'first commit' \
   '/p/t/f/repo ' \
-  'master' 'white'
+  'master' 'brblack'
 
 git_ checkout -b 'dev'
 
 assert 'get into new branch' \
   '/p/t/f/repo ' \
-  'dev' 'white'
+  'dev' 'brblack'
 
 cd $path
 mkdir $path/remote-repo


### PR DESCRIPTION
Closes #3 

It just adds a new branch to color selection.

One caveat: I think the `__mean_git_branches` is bugged, because the output from the git method being used isn't strictly the branches (it can output messages and modified files I think).

I'm leaving this be for now, but it might be why HEAD gets white on git init (test line 39).