### PR TITLE
Add git color code guide to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,45 @@
-# mean
+# mean theme
 
 [![Build Status](https://travis-ci.org/lsunsi/fish-theme-mean.svg?branch=master)](https://travis-ci.org/lsunsi/fish-theme-mean)
 
 A minimalistic single-line bilateral fish prompt theme.
 
-_Also, it tries to hurt my feelings for no reason sometimes._
+- Left: No frills short prompt path
+- Right: Sensibly color coded git information
 
 ## Installation
 
 - `fisher lsunsi/fish-theme-mean`
+
+## Git color code
+
+The choices were made with two things in mind:
+
+- Not all states need representation
+  - Symbols are useful for representing all states
+  - Choosing to ignore some states lowers cognitive load
+- Represent important states on a common git workflow
+  - Color will represent what it's important now
+  - Colors should be meaningful to what it represents
+
+What we came up to is:
+
+1. You start your new branch, so it's clean and untracked.
+2. You point it to some remote branch, so it's clean and tracked.
+3. You start hacking some code on it, so it's dirty.
+4. You commit your changes locally, so you're ahead.
+5. You push your changes to remote, so you're clean again.
+6. Someone makes some changes on remote, so you're behind.
+
+These states are currently being modelled like so:
+
+State | Color
+--- | ---
+untracked | brblack
+tracked | white
+dirty | yellow
+ahead | cyan
+behind | red
 
 ## Development
 
@@ -16,3 +47,7 @@ _Also, it tries to hurt my feelings for no reason sometimes._
 - Run `fisher .` to install local version.
 - Run `fishtape tests/*` to test run all tests.
 - Run `fisher rm mean` to remove it and get back to normal.
+
+## Considerations
+
+_This theme tries to hurt my feelings for no reason sometimes._


### PR DESCRIPTION
Closes #2 

I tried to explain our mindset alongside the color codes.
I'm not sure if it's the best decision, but I think it looks fine.

I thought we could use those little squares with colors in the table or even in the text itself, to show the colors we are referring to. Then I thought each terminal would look different. What do you think, @FelipeRosa ? I think having color names without the colors is weird, but showing colors that won't be the same in the users terminal might be weirder. I don't know.

Anyway, this clearly breaks #4 : if this one gets merged first, that one will have to adjust the doc for it's new state. No biggie tho.